### PR TITLE
Move ocean_OBC_type into MOM_open_boundary.F90

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3,7 +3,8 @@ module MOM
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_variables, only : vertvisc_type, ocean_OBC_type
+use MOM_variables, only : vertvisc_type
+use MOM_open_boundary, only : ocean_OBC_type
 
 ! A Structure with pointers to forcing fields to drive MOM;
 ! all fluxes are positive downward.

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -105,13 +105,13 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : vardesc, var_desc
+use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE
+use MOM_open_boundary, only : OBC_FLATHER_E, OBC_FLATHER_W
+use MOM_open_boundary, only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_tidal_forcing, only : tidal_forcing_sensitivity, tidal_forcing_CS
 use MOM_time_manager, only : time_type, set_time, operator(+), operator(-)
 use MOM_variables, only : BT_cont_type, alloc_bt_cont_type
-use MOM_variables, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W
-use MOM_variables, only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -47,7 +47,8 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_string_functions, only : uppercase
 use MOM_grid, only : ocean_grid_type
-use MOM_variables, only : ocean_OBC_type, BT_cont_type
+use MOM_open_boundary, only : ocean_OBC_type
+use MOM_variables, only : BT_cont_type
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -48,8 +48,9 @@ use MOM_diag_mediator, only : time_type, diag_ctrl
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
-use MOM_variables, only : ocean_OBC_type, BT_cont_type, OBC_SIMPLE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE
+use MOM_open_boundary, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_variables, only : BT_cont_type
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private

--- a/src/core/MOM_dynamics_legacy_split.F90
+++ b/src/core/MOM_dynamics_legacy_split.F90
@@ -66,7 +66,8 @@ module MOM_dynamics_legacy_split
 !********+*********+*********+*********+*********+*********+*********+**
 
 
-use MOM_variables, only : vertvisc_type, ocean_OBC_type, thermo_var_ptrs
+use MOM_open_boundary, only : ocean_OBC_type
+use MOM_variables, only : vertvisc_type, thermo_var_ptrs
 use MOM_variables, only : BT_cont_type, alloc_bt_cont_type, dealloc_bt_cont_type
 use MOM_variables, only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
 use MOM_forcing_type, only : forcing

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -3,7 +3,7 @@ module MOM_dynamics_split_RK2
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_variables,    only : vertvisc_type, ocean_OBC_type, thermo_var_ptrs
+use MOM_variables,    only : vertvisc_type, thermo_var_ptrs
 use MOM_variables,    only : BT_cont_type, alloc_bt_cont_type, dealloc_bt_cont_type
 use MOM_variables,    only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
 use MOM_forcing_type, only : forcing
@@ -45,6 +45,7 @@ use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_init, hor_v
 use MOM_interface_heights,     only : find_eta
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
+use MOM_open_boundary,         only : ocean_OBC_type
 use MOM_open_boundary,         only : Radiation_Open_Bdry_Conds, open_boundary_init
 use MOM_open_boundary,         only : open_boundary_CS
 use MOM_PressureForce,         only : PressureForce, PressureForce_init, PressureForce_CS

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -68,7 +68,7 @@ module MOM_dynamics_unsplit
 !********+*********+*********+*********+*********+*********+*********+**
 
 
-use MOM_variables, only : vertvisc_type, ocean_OBC_type, thermo_var_ptrs
+use MOM_variables, only : vertvisc_type, thermo_var_ptrs
 use MOM_variables, only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
 use MOM_forcing_type, only : forcing
 use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel_chksum
@@ -102,6 +102,7 @@ use MOM_hor_visc, only : horizontal_viscosity, hor_visc_init, hor_visc_CS
 use MOM_interface_heights, only : find_eta
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types, only : MEKE_type
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_open_boundary, only : Radiation_Open_Bdry_Conds, open_boundary_init
 use MOM_open_boundary, only : open_boundary_CS
 use MOM_PressureForce, only : PressureForce, PressureForce_init, PressureForce_CS

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -65,7 +65,7 @@ module MOM_dynamics_unsplit_RK2
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_variables, only : vertvisc_type, ocean_OBC_type, thermo_var_ptrs
+use MOM_variables, only : vertvisc_type, thermo_var_ptrs
 use MOM_variables, only : ocean_internal_state, accel_diag_ptrs, cont_diag_ptrs
 use MOM_forcing_type, only : forcing
 use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel_chksum
@@ -100,6 +100,7 @@ use MOM_hor_index, only : hor_index_type
 use MOM_hor_visc, only : horizontal_viscosity, hor_visc_init, hor_visc_CS
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types, only : MEKE_type
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_open_boundary, only : Radiation_Open_Bdry_Conds, open_boundary_init
 use MOM_open_boundary, only : open_boundary_CS
 use MOM_PressureForce, only : PressureForce, PressureForce_init, PressureForce_CS

--- a/src/core/MOM_legacy_barotropic.F90
+++ b/src/core/MOM_legacy_barotropic.F90
@@ -107,13 +107,13 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : vardesc, var_desc
+use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE
+use MOM_open_boundary, only : OBC_FLATHER_E, OBC_FLATHER_W
+use MOM_open_boundary, only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_tidal_forcing, only : tidal_forcing_sensitivity, tidal_forcing_CS
 use MOM_time_manager, only : time_type, set_time, operator(+), operator(-)
 use MOM_variables, only : BT_cont_type, alloc_bt_cont_type
-use MOM_variables, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W
-use MOM_variables, only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1,44 +1,5 @@
+!> Controls where open boundary conditions are applied 
 module MOM_open_boundary
-!***********************************************************************
-!*                   GNU General Public License                        *
-!* This file is a part of MOM.                                         *
-!*                                                                     *
-!* MOM is free software; you can redistribute it and/or modify it and  *
-!* are expected to follow the terms of the GNU General Public License  *
-!* as published by the Free Software Foundation; either version 2 of   *
-!* the License, or (at your option) any later version.                 *
-!*                                                                     *
-!* MOM is distributed in the hope that it will be useful, but WITHOUT  *
-!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
-!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
-!* License for more details.                                           *
-!*                                                                     *
-!* For the full text of the GNU General Public License,                *
-!* write to: Free Software Foundation, Inc.,                           *
-!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
-!* or see:   http://www.gnu.org/licenses/gpl.html                      *
-!***********************************************************************
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Mehmet Ilicak and Robert Hallberg, 2010                         *
-!*                                                                     *
-!*    This module implements some aspects of internal open boundary    *
-!*  conditions in MOM.                                                 *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q, CoriolisBu                            *
-!*    j+1  > o > o >   At ^:  v, tauy                                  *
-!*    j    x ^ x ^ x   At >:  u, taux                                  *
-!*    j    > o > o >   At o:  h, bathyT, buoy, tr, T, S, Rml, ustar    *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_diag_mediator, only : diag_ctrl, time_type
@@ -53,88 +14,93 @@ implicit none ; private
 
 public Radiation_Open_Bdry_Conds, open_boundary_init, open_boundary_end
 
+!> The control structure for open-boundaries
 type, public :: open_boundary_CS ; private
-  real :: gamma_uv ! The relative weighting for the baroclinic radiation
-                   ! velocities (or speed of characteristics) at the
-                   ! new time level (1) or the running mean (0) for velocities.
-                   ! Valid values range from 0 to 1, with a default of 0.3.
-  real :: gamma_h  ! The relative weighting for the baroclinic radiation
-                   ! velocities (or speed of characteristics) at the
-                   ! new time level (1) or the running mean (0) for thicknesses.
-                   ! Valid values range from 0 to 1, with a default of 0.2.
-  real :: rx_max   ! The maximum magnitude of the baroclinic radiation
-                   ! velocity (or speed of characteristics), in m s-1.  The
-                   ! default value is 10 m s-1.
+  real :: gamma_uv !< The relative weighting for the baroclinic radiation
+                   !! velocities (or speed of characteristics) at the
+                   !! new time level (1) or the running mean (0) for velocities.
+                   !! Valid values range from 0 to 1, with a default of 0.3.
+  real :: gamma_h  !< The relative weighting for the baroclinic radiation
+                   !! velocities (or speed of characteristics) at the
+                   !! new time level (1) or the running mean (0) for thicknesses.
+                   !! Valid values range from 0 to 1, with a default of 0.2.
+  real :: rx_max   !< The maximum magnitude of the baroclinic radiation
+                   !! velocity (or speed of characteristics), in m s-1.  The
+                   !! default value is 10 m s-1.
 end type open_boundary_CS
 
 integer, parameter, public :: OBC_NONE = 0, OBC_SIMPLE = 1, OBC_WALL = 2
 integer, parameter, public :: OBC_FLATHER_E = 4, OBC_FLATHER_W = 5
 integer, parameter, public :: OBC_FLATHER_N = 6, OBC_FLATHER_S = 7
 
+!> Open-boundary data
 type, public :: ocean_OBC_type
-! This structure is used to apply specified open boundary conditions.
-  logical :: apply_OBC_u_flather_east = .false.  ! If true, some zonal velocity
-  logical :: apply_OBC_u_flather_west = .false.  ! points in the local domain use flather open
-                                                 ! boundary conditions.
-  logical :: apply_OBC_v_flather_north = .false.  ! If true, some meridional velocity
-  logical :: apply_OBC_v_flather_south = .false.  ! points in the local domain use flather open
-                                                  ! boundary conditions.
-  logical :: apply_OBC_u = .false.  ! If true, some zonal or meridional velocity
-  logical :: apply_OBC_v = .false.  ! points in the local domain use open
-                                    ! boundary conditions.
+  logical :: apply_OBC_u_flather_east = .false.  !< True if any zonal velocity points in the
+                                                 !! local domain use east-facing Flather OBCs.
+  logical :: apply_OBC_u_flather_west = .false.  !< True if any zonal velocity points in the
+                                                 !! local domain use west-facing Flather OBCs.
+  logical :: apply_OBC_v_flather_north = .false. !< True if any zonal velocity points in the
+                                                 !! local domain use north-facing Flather OBCs.
+  logical :: apply_OBC_v_flather_south = .false. !< True if any zonal velocity points in the
+                                                 !! local domain use south-facing Flather OBCs.
+  logical :: apply_OBC_u = .false.  !< True if any zonal velocity points in to local domain use OBCs.
+  logical :: apply_OBC_v = .false.  !< True if any meridional velocity points in to local domain use OBCs.
   logical, pointer, dimension(:,:) :: &
-    OBC_mask_u => NULL(), & ! These arrays are true at zonal or meridional
-    OBC_mask_v => NULL()    ! velocity points that have prescribed open boundary
-                            ! conditions.
+    OBC_mask_u => NULL(), & !< True at zonal velocity points that have prescribed OBCs.
+    OBC_mask_v => NULL()    !< True at meridional velocity points that have prescribed OBCs.
+  ! These arrays indicate the kind of open boundary conditions that are to be applied at the u and v
+  ! points, and can be OBC_NONE, OBC_SIMPLE, OBC_WALL, or one of OBC_FLATHER_[EWNS].  Generally these
+  ! should be consistent with OBC_mask_[uv], with OBC_mask_[uv] .false. for OBC_kind_[uv] = NONE
+  ! and true for all other values.
   integer, pointer, dimension(:,:) :: &
-    OBC_kind_u => NULL(), & ! These arrays indicate the kind of open boundary
-    OBC_kind_v => NULL()    ! conditions that are to be applied at the u and v
-                            ! points, and can be OBC_NONE, OBC_SIMPLE, OBC_WALL,
-                            ! or one of OBC_FLATHER_[EWNS].  Generally these
-                            ! should be consistent with OBC_mask_[uv], with
-                            ! OBC_mask_[uv] .false. for OBC_kind_[uv] = NONE
-                            ! and true for all other values.
+    OBC_kind_u => NULL(), & !< Type of OBC at u-points.
+    OBC_kind_v => NULL()    !< Type of OBC at v-points.
   ! The following apply at points with OBC_kind_[uv] = OBC_FLATHER_x.
   real, pointer, dimension(:,:,:) :: &
-    rx_old_u => NULL(), &  ! The rx_old_u value for radiation coeff for u-velocity in x-direction
-    ry_old_v => NULL(), &  ! The ry_old_v value for radiation coeff for v-velocity in y-direction
-    rx_old_h => NULL(), &  ! The rx_old_h value for radiation coeff for layer thickness h in x-direction
-    ry_old_h => NULL()     ! The ry_old_h value for radiation coeff for layer thickness h in y-direction
+    rx_old_u => NULL(), &  !< The rx_old_u value for radiation coeff for u-velocity in x-direction
+    ry_old_v => NULL(), &  !< The ry_old_v value for radiation coeff for v-velocity in y-direction
+    rx_old_h => NULL(), &  !< The rx_old_h value for radiation coeff for layer thickness h in x-direction
+    ry_old_h => NULL()     !< The ry_old_h value for radiation coeff for layer thickness h in y-direction
 
   !   The following can be used to specify the outer-domain values of the
   ! surface height and barotropic velocity.  If these are not allocated, the
   ! default with Flather boundary conditions is the same as if they were
   ! filled with zeros.  With simple OBCs, these should not be allocated.
   real, pointer, dimension(:,:) :: &
-    ubt_outer => NULL(), &    ! The u-velocity in the outer domain, in m s-1.
-    vbt_outer => NULL(), &    ! The v-velocity in the outer domain, in m s-1.
-    eta_outer_u => NULL(), &  ! The sea surface height anomaly or water column
-    eta_outer_v => NULL()     ! mass anomaly in the outer domain in m or kg m-2.
+    ubt_outer => NULL(), &    !< The u-velocity in the outer domain, in m s-1.
+    vbt_outer => NULL(), &    !< The v-velocity in the outer domain, in m s-1.
+    eta_outer_u => NULL(), &  !< The SSH anomaly in the outer domain, in m or kg m-2.
+    eta_outer_v => NULL()     !< The SSH anomaly in the outer domain, in m or kg m-2.
 
   ! The following apply at points with OBC_kind_[uv] = OBC_SIMPLE.
   real, pointer, dimension(:,:,:) :: &
-    u => NULL(), &  ! The prescribed values of the zonal (u) or meridional (v)
-    v => NULL(), &  ! velocities at OBC points, in m s-1.
-    uh => NULL(), & ! The prescribed values of the zonal (uh) or meridional (vh)
-    vh => NULL()    ! volume transports at OBC points, in m3 s-1.
+    u => NULL(), &  !< The prescribed values of the zonal velocity (u) at OBC points.
+    v => NULL(), &  !< The prescribed values of the meridional velocity (v) at OBC points.
+    uh => NULL(), & !< The prescribed values of the zonal volume transport (uh) at OBC points.
+    vh => NULL()    !< The prescribed values of the meridional volume transport (vh) at OBC points.
 end type ocean_OBC_type
 
 integer :: id_clock_pass
 
+character(len=40)  :: mod = "MOM_open_boundary" ! This module's name.
+! This include declares and sets the variable "version".
+#include "version_variable.h"
+
 contains
 
+!> Diagnose radiation conditions at open boundaries
 subroutine Radiation_Open_Bdry_Conds(OBC, u_new, u_old, v_new, v_old, &
                                      h_new, h_old, G, CS)
-  type(ocean_grid_type),                     intent(inout) :: G
-  type(ocean_OBC_type),                      pointer       :: OBC
+  type(ocean_grid_type),                     intent(inout) :: G !< Ocean grid structure
+  type(ocean_OBC_type),                      pointer       :: OBC !< Open boundary data
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u_new
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u_old
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v_new
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v_old
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h_new
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h_old
-  type(open_boundary_CS),                    pointer       :: CS
-
+  type(open_boundary_CS),                    pointer       :: CS !< Open boundary control structure
+  ! Local variables
   real :: dhdt, dhdx, gamma_u, gamma_h, gamma_v
   real :: rx_max, ry_max ! coefficients for radiation
   real :: rx_new, rx_avg ! coefficients for radiation
@@ -239,26 +205,18 @@ subroutine Radiation_Open_Bdry_Conds(OBC, u_new, u_old, v_new, v_old, &
 
 end subroutine Radiation_Open_Bdry_Conds
 
+!> Initialize open boundary control structure
 subroutine open_boundary_init(Time, G, param_file, diag, CS)
-  type(time_type), target, intent(in)    :: Time
-  type(ocean_grid_type),   intent(in)    :: G
-  type(param_file_type),   intent(in)    :: param_file
-  type(diag_ctrl), target, intent(inout) :: diag
-  type(open_boundary_CS),  pointer       :: CS
-! Arguments: Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-! This include declares and sets the variable "version".
-#include "version_variable.h"
-  character(len=40)  :: mod = "MOM_open_boundary" ! This module's name.
+  type(time_type), target, intent(in)    :: Time !< Current model time
+  type(ocean_grid_type),   intent(in)    :: G !< Ocean grid structure
+  type(param_file_type),   intent(in)    :: param_file !< Parameter file handle
+  type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure
+  type(open_boundary_CS),  pointer       :: CS !< Open boundary control structure
+  ! Local variables
   logical :: flather_east, flather_west, flather_north, flather_south
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "continuity_init called with associated control structure.")
+    call MOM_error(WARNING, "MOM_open_boundary: open_boundary_init called with associated control structure.")
     return
   endif
 
@@ -307,9 +265,26 @@ subroutine open_boundary_init(Time, G, param_file, diag, CS)
 
 end subroutine open_boundary_init
 
+!> Deallocate open boundary data
 subroutine open_boundary_end(CS)
-  type(open_boundary_CS), pointer :: CS
+  type(open_boundary_CS), pointer :: CS !< Open boundary control structure
   deallocate(CS)
 end subroutine open_boundary_end
+
+!> \namespace mom_open_boundary
+!! This module implements some aspects of internal open boundary
+!! conditions in MOM.
+!!
+!! A small fragment of the grid is shown below:
+!!
+!!    j+1  x ^ x ^ x   At x:  q, CoriolisBu
+!!    j+1  > o > o >   At ^:  v, tauy
+!!    j    x ^ x ^ x   At >:  u, taux
+!!    j    > o > o >   At o:  h, bathyT, buoy, tr, T, S, Rml, ustar
+!!    j-1  x ^ x ^ x
+!!        i-1  i  i+1  At x & ^:
+!!           i  i+1    At > & o:
+!!
+!! The boundaries always run through q grid points (x).
 
 end module MOM_open_boundary

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -46,8 +46,6 @@ use MOM_domains, only : pass_var, pass_vector
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
-use MOM_variables, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 
 implicit none ; private
 
@@ -68,6 +66,58 @@ type, public :: open_boundary_CS ; private
                    ! velocity (or speed of characteristics), in m s-1.  The
                    ! default value is 10 m s-1.
 end type open_boundary_CS
+
+integer, parameter, public :: OBC_NONE = 0, OBC_SIMPLE = 1, OBC_WALL = 2
+integer, parameter, public :: OBC_FLATHER_E = 4, OBC_FLATHER_W = 5
+integer, parameter, public :: OBC_FLATHER_N = 6, OBC_FLATHER_S = 7
+
+type, public :: ocean_OBC_type
+! This structure is used to apply specified open boundary conditions.
+  logical :: apply_OBC_u_flather_east = .false.  ! If true, some zonal velocity
+  logical :: apply_OBC_u_flather_west = .false.  ! points in the local domain use flather open
+                                                 ! boundary conditions.
+  logical :: apply_OBC_v_flather_north = .false.  ! If true, some meridional velocity
+  logical :: apply_OBC_v_flather_south = .false.  ! points in the local domain use flather open
+                                                  ! boundary conditions.
+  logical :: apply_OBC_u = .false.  ! If true, some zonal or meridional velocity
+  logical :: apply_OBC_v = .false.  ! points in the local domain use open
+                                    ! boundary conditions.
+  logical, pointer, dimension(:,:) :: &
+    OBC_mask_u => NULL(), & ! These arrays are true at zonal or meridional
+    OBC_mask_v => NULL()    ! velocity points that have prescribed open boundary
+                            ! conditions.
+  integer, pointer, dimension(:,:) :: &
+    OBC_kind_u => NULL(), & ! These arrays indicate the kind of open boundary
+    OBC_kind_v => NULL()    ! conditions that are to be applied at the u and v
+                            ! points, and can be OBC_NONE, OBC_SIMPLE, OBC_WALL,
+                            ! or one of OBC_FLATHER_[EWNS].  Generally these
+                            ! should be consistent with OBC_mask_[uv], with
+                            ! OBC_mask_[uv] .false. for OBC_kind_[uv] = NONE
+                            ! and true for all other values.
+  ! The following apply at points with OBC_kind_[uv] = OBC_FLATHER_x.
+  real, pointer, dimension(:,:,:) :: &
+    rx_old_u => NULL(), &  ! The rx_old_u value for radiation coeff for u-velocity in x-direction
+    ry_old_v => NULL(), &  ! The ry_old_v value for radiation coeff for v-velocity in y-direction
+    rx_old_h => NULL(), &  ! The rx_old_h value for radiation coeff for layer thickness h in x-direction
+    ry_old_h => NULL()     ! The ry_old_h value for radiation coeff for layer thickness h in y-direction
+
+  !   The following can be used to specify the outer-domain values of the
+  ! surface height and barotropic velocity.  If these are not allocated, the
+  ! default with Flather boundary conditions is the same as if they were
+  ! filled with zeros.  With simple OBCs, these should not be allocated.
+  real, pointer, dimension(:,:) :: &
+    ubt_outer => NULL(), &    ! The u-velocity in the outer domain, in m s-1.
+    vbt_outer => NULL(), &    ! The v-velocity in the outer domain, in m s-1.
+    eta_outer_u => NULL(), &  ! The sea surface height anomaly or water column
+    eta_outer_v => NULL()     ! mass anomaly in the outer domain in m or kg m-2.
+
+  ! The following apply at points with OBC_kind_[uv] = OBC_SIMPLE.
+  real, pointer, dimension(:,:,:) :: &
+    u => NULL(), &  ! The prescribed values of the zonal (u) or meridional (v)
+    v => NULL(), &  ! velocities at OBC points, in m s-1.
+    uh => NULL(), & ! The prescribed values of the zonal (uh) or meridional (vh)
+    vh => NULL()    ! volume transports at OBC points, in m3 s-1.
+end type ocean_OBC_type
 
 integer :: id_clock_pass
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -235,59 +235,6 @@ type, public :: vertvisc_type
                         ! at the interfaces between each layer, in m2 s-2.
 end type vertvisc_type
 
-integer, parameter, public :: OBC_NONE = 0, OBC_SIMPLE = 1, OBC_WALL = 2
-integer, parameter, public :: OBC_FLATHER_E = 4, OBC_FLATHER_W = 5
-integer, parameter, public :: OBC_FLATHER_N = 6, OBC_FLATHER_S = 7
-
-type, public :: ocean_OBC_type
-! This structure is used to apply specified open boundary conditions.
-  logical :: apply_OBC_u_flather_east = .false.  ! If true, some zonal velocity
-  logical :: apply_OBC_u_flather_west = .false.  ! points in the local domain use flather open
-                                                 ! boundary conditions.
-  logical :: apply_OBC_v_flather_north = .false.  ! If true, some meridional velocity
-  logical :: apply_OBC_v_flather_south = .false.  ! points in the local domain use flather open
-                                                  ! boundary conditions.
-  logical :: apply_OBC_u = .false.  ! If true, some zonal or meridional velocity
-  logical :: apply_OBC_v = .false.  ! points in the local domain use open
-                                    ! boundary conditions.
-  logical, pointer, dimension(:,:) :: &
-    OBC_mask_u => NULL(), & ! These arrays are true at zonal or meridional
-    OBC_mask_v => NULL()    ! velocity points that have prescribed open boundary
-                            ! conditions.
-  integer, pointer, dimension(:,:) :: &
-    OBC_kind_u => NULL(), & ! These arrays indicate the kind of open boundary
-    OBC_kind_v => NULL()    ! conditions that are to be applied at the u and v
-                            ! points, and can be OBC_NONE, OBC_SIMPLE, OBC_WALL,
-                            ! or one of OBC_FLATHER_[EWNS].  Generally these
-                            ! should be consistent with OBC_mask_[uv], with
-                            ! OBC_mask_[uv] .false. for OBC_kind_[uv] = NONE
-                            ! and true for all other values.
-  ! The following apply at points with OBC_kind_[uv] = OBC_FLATHER_x.
-  real, pointer, dimension(:,:,:) :: &
-    rx_old_u => NULL(), &  ! The rx_old_u value for radiation coeff for u-velocity in x-direction
-    ry_old_v => NULL(), &  ! The ry_old_v value for radiation coeff for v-velocity in y-direction
-    rx_old_h => NULL(), &  ! The rx_old_h value for radiation coeff for layer thickness h in x-direction
-    ry_old_h => NULL()     ! The ry_old_h value for radiation coeff for layer thickness h in y-direction
-
-  !   The following can be used to specify the outer-domain values of the
-  ! surface height and barotropic velocity.  If these are not allocated, the
-  ! default with Flather boundary conditions is the same as if they were
-  ! filled with zeros.  With simple OBCs, these should not be allocated.
-  real, pointer, dimension(:,:) :: &
-    ubt_outer => NULL(), &    ! The u-velocity in the outer domain, in m s-1.
-    vbt_outer => NULL(), &    ! The v-velocity in the outer domain, in m s-1.
-    eta_outer_u => NULL(), &  ! The sea surface height anomaly or water column
-    eta_outer_v => NULL()     ! mass anomaly in the outer domain in m or kg m-2.
-
-  ! The following apply at points with OBC_kind_[uv] = OBC_SIMPLE.
-  real, pointer, dimension(:,:,:) :: &
-    u => NULL(), &  ! The prescribed values of the zonal (u) or meridional (v)
-    v => NULL(), &  ! velocities at OBC points, in m s-1.
-    uh => NULL(), & ! The prescribed values of the zonal (uh) or meridional (vh)
-    vh => NULL()    ! volume transports at OBC points, in m3 s-1.
-end type ocean_OBC_type
-
-
 type, public :: BT_cont_type
   real, pointer, dimension(:,:) :: &
     FA_u_EE => NULL(), &  ! The FA_u_XX variables are the effective open face

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -21,6 +21,9 @@ use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, write_field
 use MOM_io, only : EAST_FACE, NORTH_FACE
+use MOM_open_boundary, only : ocean_OBC_type
+use MOM_open_boundary, only : OBC_NONE, OBC_SIMPLE, OBC_FLATHER_E, OBC_FLATHER_W
+use MOM_open_boundary, only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_grid_initialize, only : initialize_masks, set_grid_metrics
 use MOM_restart, only : restore_state, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, set_up_sponge_ML_density
@@ -30,9 +33,7 @@ use MOM_ALE_sponge, only : ALE_sponge_CS
 use MOM_string_functions, only : uppercase
 use MOM_time_manager, only : time_type, set_time
 use MOM_tracer_registry, only : add_tracer_OBC_values, tracer_registry_type
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
-use MOM_variables, only : OBC_NONE, OBC_SIMPLE, OBC_FLATHER_E, OBC_FLATHER_W
-use MOM_variables, only : OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : setVerticalGridAxes, verticalGrid_type
 use MOM_ALE, only : pressure_gradient_plm
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -93,8 +93,8 @@ use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_grid,                  only : ocean_grid_type
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
-use MOM_variables,             only : ocean_OBC_type, OBC_FLATHER_E, OBC_FLATHER_W
-use MOM_variables,             only : OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_open_boundary,         only : ocean_OBC_type, OBC_FLATHER_E, OBC_FLATHER_W
+use MOM_open_boundary,         only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid,          only : verticalGrid_type
 
 implicit none ; private

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -64,7 +64,7 @@ use MOM_kappa_shear, only : kappa_shear_is_used
 use MOM_io, only : vardesc, var_desc
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_variables, only : thermo_var_ptrs
-use MOM_variables, only : vertvisc_type, ocean_OBC_type
+use MOM_variables, only : vertvisc_type
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -82,12 +82,13 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE
 use MOM_PointAccel, only : write_u_accel, write_v_accel, PointAccel_init
 use MOM_PointAccel, only : PointAccel_CS
 use MOM_time_manager, only : time_type, time_type_to_real, operator(-)
 use MOM_variables, only : thermo_var_ptrs, vertvisc_type
 use MOM_variables, only : cont_diag_ptrs, accel_diag_ptrs
-use MOM_variables, only : ocean_internal_state, ocean_OBC_type, OBC_SIMPLE
+use MOM_variables, only : ocean_internal_state
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -62,13 +62,14 @@ use MOM_forcing_type, only : forcing
 use MOM_hor_index, only : hor_index_type
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -73,6 +73,7 @@ use MOM_forcing_type, only : forcing
 use MOM_hor_index, only : hor_index_type
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
@@ -80,7 +81,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
 use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : extract_coupler_values, set_coupler_values

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -14,9 +14,9 @@ use MOM_checksums,       only : hchksum
 use MOM_error_handler,   only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 use MOM_file_parser,     only : get_param, log_version, param_file_type
 use MOM_grid,            only : ocean_grid_type
+use MOM_open_boundary,   only : ocean_OBC_type, OBC_FLATHER_E
+use MOM_open_boundary,   only : OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_tracer_registry, only : tracer_registry_type, tracer_type, MOM_tracer_chksum
-use MOM_variables,       only : ocean_OBC_type, OBC_FLATHER_E
-use MOM_variables,       only : OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid,    only : verticalGrid_type
 
 implicit none ; private

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -36,11 +36,12 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing, optics_type
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : MOM_restart_CS
 use MOM_sponge, only : sponge_CS
 use MOM_ALE_sponge, only : ALE_sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
-use MOM_variables, only : surface, ocean_OBC_type, thermo_var_ptrs
+use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
 #include <MOM_memory.h>

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -21,9 +21,10 @@ use MOM_MEKE_types,            only : MEKE_type
 use MOM_neutral_diffusion,     only : neutral_diffusion_init, neutral_diffusion_end
 use MOM_neutral_diffusion,     only : neutral_diffusion_CS
 use MOM_neutral_diffusion,     only : neutral_diffusion_calc_coeffs, neutral_diffusion
+use MOM_open_boundary,         only : ocean_OBC_type, OBC_FLATHER_E
+use MOM_open_boundary,         only : OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_tracer_registry,       only : tracer_registry_type, tracer_type, MOM_tracer_chksum
-use MOM_variables,             only : ocean_OBC_type, thermo_var_ptrs, OBC_FLATHER_E
-use MOM_variables,             only : OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_variables,             only : thermo_var_ptrs
 use MOM_verticalGrid,          only : verticalGrid_type
 
 implicit none ; private

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -62,13 +62,14 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -63,6 +63,7 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
@@ -70,7 +71,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
 use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -63,6 +63,7 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
@@ -70,7 +71,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
 use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -63,6 +63,7 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
@@ -70,7 +71,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_tracer_registry, only : tracer_vertdiff
 use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -59,12 +59,13 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
-use MOM_variables, only : surface, ocean_OBC_type
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_util, only : set_coupler_values, ind_csurf

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -9,7 +9,7 @@ use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher, vardesc
 use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -24,8 +24,9 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -27,7 +27,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher, vardesc
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -27,10 +27,8 @@ use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
-use MOM_variables, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -10,7 +10,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher, vardesc
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -26,7 +26,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -24,9 +24,8 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
-use MOM_variables, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -24,8 +24,8 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_tracer_registry, only : tracer_registry_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -23,7 +23,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 implicit none ; private
 

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -23,7 +23,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -28,8 +28,8 @@ use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher, vardesc
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_tracer_registry, only : tracer_registry_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -28,8 +28,8 @@ use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type
+use MOM_tracer_registry, only : tracer_registry_type
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -26,10 +26,11 @@ use MOM_grid, only : ocean_grid_type
 use MOM_io, only : close_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
-use MOM_variables, only : thermo_var_ptrs, ocean_OBC_type, OBC_NONE, OBC_SIMPLE
-use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
+use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 implicit none ; private


### PR DESCRIPTION
This moves the ocean_OBC_type from MOM_variables.F90 to MOM_open_boundary.F90.

- The is part way to consolidating the all the open boundary parts into one module. The latter is not yet where anything important happens but changes-yet-to-come will change that.
- The type ocean_OBC_type is typically passed around as `OBC` and is already used to store flags, masks, and input data for simple OBCs, and additionally phase speeds etc for Flather, but oddly not all the Flather parameters. It makes sense to put everything into `OBC` and have it set up by only one module rather than have it allocated, set and touched by several different modules.

@kshedstrom This is just two commits (one move, one doxygenization) but forms the basis of the next several changes I'm suggesting.

