### PR TITLE
*Change bottom drag behavior along open boundaries

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2360,7 +2360,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   CS%useMEKE = MEKE_init(Time, G, param_file, diag, CS%MEKE_CSp, CS%MEKE, CS%restart_CSp)
 
   call VarMix_init(Time, G, param_file, diag, CS%VarMix)
-  call set_visc_init(Time, G, GV, param_file, diag, CS%visc, CS%set_visc_CSp)
+  call set_visc_init(Time, G, GV, param_file, diag, CS%visc, CS%set_visc_CSp,CS%OBC)
   if (CS%split) then
     allocate(eta(SZI_(G),SZJ_(G))) ; eta(:,:) = 0.0
     if (CS%legacy_split) then


### PR DESCRIPTION
 -Use interior velocities and thicknesses for the calculation
 -of bottom stress along open boundaries. This changes answers
 -in circle_obcs,DOME and Tidal_Bay. This change makes circle_obcs
 -insensitive to exterior velocities.