### PR TITLE
Obc patches

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3947,17 +3947,17 @@ subroutine open_boundary_register_restarts(HI, GV, OBC_CS,restart_CSp)
     allocate(OBC_CS%rx_normal(HI%isdB:HI%iedB,HI%jsd:HI%jed,GV%ke))
     OBC_CS%rx_normal(:,:,:) = 0.0
     vd = var_desc("rx_normal","m s-1", "Normal Phase Speed for EW OBCs",'u','L')
-    call register_restart_field(OBC_CS%rx_normal, vd, .true., restart_CSp)
+    call register_restart_field(OBC_CS%rx_normal, vd, .false., restart_CSp)
     allocate(OBC_CS%ry_normal(HI%isd:HI%ied,HI%jsdB:HI%jedB,GV%ke))
     OBC_CS%ry_normal(:,:,:) = 0.0
     vd = var_desc("ry_normal","m s-1", "Normal Phase Speed for NS OBCs",'v','L')
-    call register_restart_field(OBC_CS%ry_normal, vd, .true., restart_CSp)
+    call register_restart_field(OBC_CS%ry_normal, vd, .false., restart_CSp)
   endif
   if (OBC_CS%oblique_BCs_exist_globally) then
     allocate(OBC_CS%cff_normal(HI%IsdB:HI%IedB,HI%jsdB:HI%jedB,GV%ke))
     OBC_CS%cff_normal(:,:,:) = 0.0
     vd = var_desc("cff_normal","m s-1", "denominator for oblique OBCs",'q','L')
-    call register_restart_field(OBC_CS%cff_normal, vd, .true., restart_CSp)
+    call register_restart_field(OBC_CS%cff_normal, vd, .false., restart_CSp)
   endif
 
 end subroutine open_boundary_register_restarts

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -520,7 +520,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
     if (k == 1) then
       call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
-               interp_method='bilinear',src_modulo=reentrant_x)
+               interp_method='bilinear',src_modulo=.true.)
     endif
 
     if (debug) then
@@ -796,7 +796,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
     ! call fms routine horiz_interp to interpolate input level data to model horizontal grid
     if (k == 1) then
       call horiz_interp_new(Interp, x_in, y_in, lon_out(is:ie,js:je), lat_out(is:ie,js:je), &
-               interp_method='bilinear', src_modulo=reentrant_x)
+               interp_method='bilinear', src_modulo=.true.)
     endif
 
     if (debug) then


### PR DESCRIPTION
Two updates here related to initialization. The first is to assume that the source data for online regridding is zonally re-entrant .  This allows for initialization of regional models from WOA or other global analyses. The second gets rid of the restart requirement for "rx_normal" in OBC cases where we want to restart from parent model data  